### PR TITLE
Include ActiveSupport::Testing::Assertions in ActiveJob::TestHelpers

### DIFF
--- a/activejob/lib/active_job/test_helper.rb
+++ b/activejob/lib/active_job/test_helper.rb
@@ -8,6 +8,8 @@ module ActiveJob
     delegate :enqueued_jobs, :enqueued_jobs=,
       :performed_jobs, :performed_jobs=,
       to: :queue_adapter
+    
+    include ActiveSupport::Testing::Assertions
 
     module TestQueueAdapter
       extend ActiveSupport::Concern


### PR DESCRIPTION
After upgrading to Rails 6.1 I'm getting a `undefined method 'assert_nothing_raised'` using `ActiveJob::TestHelpers` and `assert_enqueued_jobs` in RSpec.

Adding this module fixes it, however not knowing the internals too well, I'm unsure whether it's the right fix.

ruby 2.7.2p137
rails 6.1
rspec 3.9.3
rspec-rails 4.0.1